### PR TITLE
fix import abort from flask not werkzeug

### DIFF
--- a/my_app/product/views.py
+++ b/my_app/product/views.py
@@ -1,4 +1,4 @@
-from werkzeug import abort
+from flask import abort
 from flask import render_template
 from flask import Blueprint
 from my_app.product.models import PRODUCTS


### PR DESCRIPTION
abort cannot be imported from werkzeug, but can be found in flask.

i tested it and it fixed the import issue when running the app.